### PR TITLE
Implement K60 SPI driver

### DIFF
--- a/cpu/arm/k60/Makefile.k60
+++ b/cpu/arm/k60/Makefile.k60
@@ -36,6 +36,7 @@ CONTIKI_TARGET_SOURCEFILES += \
   port.c \
   uart.c \
   rtc.c \
+  spi.c \
   rtimer-arch.c \
   dbg-uart.c \
   clock.c \

--- a/cpu/arm/k60/clock.c
+++ b/cpu/arm/k60/clock.c
@@ -30,6 +30,8 @@ static volatile clock_time_t current_tick;
 static volatile unsigned long current_seconds = 0;
 static volatile unsigned long second_countdown = CLOCK_SECOND;
 
+static volatile uint8_t waiting_flag = 0;
+
 static struct rtimer rt_clock;
 
 /* This is based on the MC1322x clock module rtimer implementation. */
@@ -111,6 +113,51 @@ clock_wait(clock_time_t delay)
 }
 #endif /* 0 */
 
+/**
+ * Delay the CPU by delay microseconds.
+ *
+ * \param delay_us microsecond delay.
+ */
+void
+clock_delay_usec(uint16_t delay_us) {
+  /* Don't hang on zero µs sleep. */
+  if (delay_us == 0) return;
+
+  /* Enable PIT peripheral clock */
+  BITBAND_REG(SIM->SCGC6, SIM_SCGC6_PIT_SHIFT) = 1;
+
+  /* Disable timer, disable interrupts */
+  BITBAND_REG(PIT->CHANNEL[BOARD_DELAY_PIT_CHANNEL].TCTRL, PIT_TCTRL_TEN_SHIFT) = 0;
+  BITBAND_REG(PIT->CHANNEL[BOARD_DELAY_PIT_CHANNEL].TCTRL, PIT_TCTRL_TIE_SHIFT) = 0;
+  /* Clear interrupt flag */
+  BITBAND_REG(PIT->CHANNEL[BOARD_DELAY_PIT_CHANNEL].TFLG, PIT_TFLG_TIF_SHIFT) = 1;
+
+  /* Enable interrupts, disable chaining, disable timer */
+  PIT->CHANNEL[BOARD_DELAY_PIT_CHANNEL].TCTRL = PIT_TCTRL_TIE_MASK;
+
+  /* It would be possible to get a better rounding if we allowed a division
+   * here, but using a runtime division makes this all sorts of complicated.
+   * In order to get a proper division we would have to extend to a 64 bit int
+   * because of overflows in the multiplication between delay_us and
+   * PIT_module_frequency when PIT_module_frequency > 65535, at least if all
+   * possible delay_us values should be allowed. */
+  /* Set up timer */
+  PIT->CHANNEL[BOARD_DELAY_PIT_CHANNEL].LDVAL =
+      PIT_LDVAL_TSV(PIT_ticks_per_usec * (uint32_t)delay_us);
+
+  /* Set flag, will be cleared by ISR when timer fires. */
+  waiting_flag = 1;
+
+  /* Enable timer */
+  BITBAND_REG(PIT->CHANNEL[BOARD_DELAY_PIT_CHANNEL].TCTRL, PIT_TCTRL_TEN_SHIFT) = 1;
+
+  while(waiting_flag) {
+    /* Don't go to deeper sleep modes as that will stop the PIT module clock. */
+    power_mode_wait();
+  }
+}
+
+
 /*
  * Initialize the clock module.
  */
@@ -119,4 +166,24 @@ void
 clock_init(void)
 {
   rtimer_set(&rt_clock, RTIMER_NOW() + RTIMER_SECOND/CLOCK_SECOND, 1, (rtimer_callback_t)rt_do_clock, NULL);
+
+  /* Enable PIT peripheral clock */
+  BITBAND_REG(SIM->SCGC6, SIM_SCGC6_PIT_SHIFT) = 1;
+
+  /* Reset PIT logic to a known state */
+  /* The MCR really only controls the MDIS (module disable) and FRZ (debug
+   * freeze) bits of the module. */
+  PIT->MCR = 0x00;
+
+  /* Enable clock_delay_usec PIT IRQ in NVIC. */
+  NVIC_EnableIRQ(BOARD_DELAY_PIT_IRQn);
+}
+
+/* PIT interrupt handler for clock_delay_usec */
+void BOARD_DELAY_PIT_ISR(void) {
+  /* Clear interrupt flag */
+  BITBAND_REG(PIT->CHANNEL[BOARD_DELAY_PIT_CHANNEL].TFLG, PIT_TFLG_TIF_SHIFT) = 1;
+
+  /* Clear flag set by clock_delay_usec() */
+  waiting_flag = 0;
 }

--- a/cpu/arm/k60/drivers/power-modes.h
+++ b/cpu/arm/k60/drivers/power-modes.h
@@ -60,6 +60,14 @@ void power_mode_lls(void);
 /* void power_mode_vlls2(void); */
 /* void power_mode_vlls3(void); */
 
+/** Wait in power save for a condition to become true. */
+#define COND_WAIT(condition) {while (condition) { power_mode_wait(); }}
+#define COND_STOP(condition) {while (condition) { power_mode_stop(); }}
+#define COND_VLPS(condition) {while (condition) { power_mode_vlps(); }}
+#define COND_LLS(condition)  {while (condition) { power_mode_lls(); }}
+
+
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/cpu/arm/k60/drivers/spi-k60.h
+++ b/cpu/arm/k60/drivers/spi-k60.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2014, Eistec AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Mulle platform port of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         SPI driver for Kinetis K60.
+ * \author
+ *         Joakim Gebart <joakim.gebart@eistec.se>
+ */
+
+#ifndef CPU_ARM_K60_SPI_H_
+#define CPU_ARM_K60_SPI_H_
+
+#include <stddef.h>
+#include "K60.h"
+#include "spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Number of CTAR registers in SPI module, see K60 Reference Manual for details. */
+#define NUM_CTAR 2
+
+typedef enum spi_ctar {
+  SPI_CTAR_0 = 0,
+  SPI_CTAR_1 = 1,
+} spi_ctar_t;
+
+typedef enum spi_bus {
+  SPI_0 = 0,
+  SPI_1 = 1,
+  SPI_2 = 2
+} spi_bus_t;
+
+/**
+ * SPI bus configuration structure.
+ */
+typedef struct spi_config {
+  uint32_t sck_freq;
+  uint8_t frame_size;
+  uint8_t cpol;
+  uint8_t cpha;
+} spi_config_t;
+
+typedef enum spi_transfer_flag {
+  SPI_TRANSFER_DONE = 0,
+  SPI_TRANSFER_CONT = 1
+} spi_transfer_flag_t;
+
+/**
+ * Request exclusive access to the bus.
+ *
+ * This is used to ensure that different drivers do not attempt to use the bus
+ * at the same time.
+ *
+ * \note This function will block until the bus is free.
+ *
+ * \param spi_num The SPI module number.
+ */
+void spi_acquire_bus(const spi_bus_t spi_num);
+
+/**
+ * Release exclusive access of the bus.
+ *
+ * \param spi_num The SPI module number.
+ */
+void spi_release_bus(const spi_bus_t spi_num);
+
+/**
+ * Test if the bus lock is currently being held by someone.
+ *
+ * \param spi_num The SPI module number.
+ */
+int spi_is_busy(const spi_bus_t spi_num);
+
+/**
+ * Initialize the SPI hardware module.
+ *
+ * \param spi_num The SPI module number.
+ */
+void spi_hw_init_master(const spi_bus_t spi_num);
+
+/**
+ * Perform a series of writes followed by a series of reads to/from the SPI bus.
+ *
+ * \param spi_num SPI module number.
+ * \param ctas The CTAR register to use for timing information (0 or 1)
+ * \param cs The chip select pins to assert. Bitmask, not PCS number.
+ * \param cont Whether to keep asserting the chip select pin after the series of transfers ends.
+ * \param data_out Pointer to data to send.
+ * \param data_in Pointer to store received data.
+ * \param count_out Number of bytes to write.
+ * \param count_in Number of bytes to read.
+ */
+int spi_transfer_blocking(const spi_bus_t spi_num, const spi_ctar_t ctas, const uint32_t cs,
+             const spi_transfer_flag_t cont, const uint8_t *data_out,
+             uint8_t *data_in, size_t count_out, size_t count_in);
+
+/**
+ * Enable the SPI hardware module (enable clock gate).
+ *
+ * \param spi_num The SPI module number.
+ */
+void spi_start(const spi_bus_t spi_num);
+
+/**
+ * Disable the SPI hardware module (disable clock gate).
+ *
+ * \param spi_num The SPI module number.
+ */
+void spi_stop(const spi_bus_t spi_num);
+
+/**
+ * Set transfer parameters for the bus.
+ *
+ * This will update the appropriate CTAR register with proper scaler and
+ * prescaler values based on the current clock settings.
+ *
+ * Remember to call this every time the bus clock changes.
+ *
+ * Never call this function while the SPI bus has an active transfer going.
+ *
+ * The struct pointed to by config is expected to remain a valid configuration
+ * in order for spi_refresh_params to work properly.
+ *
+ * \param spi_num The SPI module number.
+ * \param ctas Index of the chosen CTAR register.
+ * \param config Pointer to bus configuration information.
+ */
+void spi_set_params(const spi_bus_t spi_num, const spi_ctar_t ctas, const spi_config_t* config);
+
+/**
+ * Refresh the latest configuration for the SPI bus.
+ *
+ * This should be run after changing the bus clock frequency in order to set new
+ * prescaler and scaler settings in the SPI hardware module.
+ */
+void spi_refresh_params(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* CPU_ARM_K60_SPI_H_ */

--- a/cpu/arm/k60/drivers/spi.c
+++ b/cpu/arm/k60/drivers/spi.c
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2014, Eistec AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Mulle platform port of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         SPI bus driver for Kinetis K60.
+ * \author
+ *         Joakim Gebart <joakim.gebart@eistec.se>
+ */
+
+#include <stdint.h>
+#include "spi-k60.h"
+#include "K60.h"
+#include "synchronization.h"
+#include "power-modes.h"
+
+#define SPI_IDLE_DATA (0xffff)
+
+/* one config per CTAR instance */
+/* This is an array of pointers to the current SPI bus configurations. The saved
+ * pointers are used to be able to update the prescaler and scaler settings
+ * whenever the bus clock frequency changes. */
+static const spi_config_t *spi_conf[NUM_SPI][NUM_CTAR] = {{NULL}};
+
+static lock_t spi_lock[NUM_SPI] = {2, 2, 2}; /* Block access by default until spi_hw_init_master has been run */
+
+static volatile uint8_t spi_waiting_flag[NUM_SPI] = {0};
+
+/**
+ * Find the prescaler and scaler settings that will yield a clock frequency
+ * as close as possible (but not above) the target frequency, given the module
+ * runs at module_clock Hz.
+ *
+ * Hardware properties (Baud rate configuration):
+ * Possible prescalers: 2, 3, 5, 7
+ * Possible scalers: 2, 4, 6 (sic!), 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768
+ *
+ * SCK baud rate = (f_SYS/PBR) x [(1+DBR)/BR]
+ *
+ * where PBR is the prescaler, BR is the scaler, DBR is the Double BaudRate bit.
+ *
+ * \note We are not using the DBR bit because it may affect the SCK duty cycle.
+ */
+static int find_closest_scalers(unsigned int module_clock, unsigned int target_clock, uint32_t *settings)
+{
+  int i;
+  int k;
+  int freq;
+  static const int num_scalers = 16;
+  static const int num_prescalers = 4;
+  static const unsigned int scalers[16] = {
+        2,     4,     6,     8,    16,    32,    64,   128,
+      256,   512,  1024,  2048,  4096,  8192, 16384, 32768
+  };
+  static const unsigned int prescalers[4] = {2, 3, 5, 7};
+
+  int closest_frequency = -1;
+  int closest_scaler = -1;
+  int closest_prescaler = -1;
+
+  /* Test all combinations until we arrive close to the target clock */
+  for (i = 0; i < num_prescalers; ++i)
+  {
+    for (k = 0; k < num_scalers; ++k)
+    {
+      freq = module_clock / (scalers[k] * prescalers[i]);
+      if (freq <= target_clock)
+      {
+        /* Found closest lower frequency at this prescaler setting,
+         * compare to the best result */
+        if (closest_frequency < freq)
+        {
+          closest_frequency = freq;
+          closest_scaler = k;
+          closest_prescaler = i;
+        }
+        break;
+      }
+    }
+  }
+  if (closest_frequency < 0)
+  {
+    /* Error, no solution found, this line is never reachable with current
+     * hardware settings unless a _very_ low target clock is requested.
+     * (scaler_max * prescaler_max) = 229376 => target_min@100MHz = 435 Hz*/
+    return -1;
+  }
+
+  /* Clear old timing values */
+  (*settings) &= ~(SPI_CTAR_BR_MASK | SPI_CTAR_DT_MASK | SPI_CTAR_ASC_MASK |
+      SPI_CTAR_CSSCK_MASK | SPI_CTAR_PBR_MASK | SPI_CTAR_PDT_MASK |
+      SPI_CTAR_PASC_MASK | SPI_CTAR_PCSSCK_MASK | SPI_CTAR_DBR_MASK);
+
+  /* Set new timings */
+  (*settings) |= SPI_CTAR_BR(closest_scaler) | SPI_CTAR_PBR(closest_prescaler) |
+      SPI_CTAR_ASC(closest_scaler) | SPI_CTAR_PASC(closest_prescaler) |
+      SPI_CTAR_CSSCK(closest_scaler) | SPI_CTAR_PCSSCK(closest_prescaler) |
+      SPI_CTAR_DT(closest_scaler) | SPI_CTAR_PDT(closest_prescaler);
+
+  return 0;
+}
+
+void spi_acquire_bus(const spi_bus_t spi_num) {
+  lock_acquire(&spi_lock[spi_num]);
+}
+
+void spi_release_bus(const spi_bus_t spi_num) {
+  lock_release(&spi_lock[spi_num]);
+}
+
+int spi_is_busy(const spi_bus_t spi_num) {
+  return (spi_lock[spi_num] != 0);
+}
+
+void
+spi_hw_init_master(const spi_bus_t spi_num) {
+  /* Clear lock variable */
+  spi_lock[spi_num] = 0;
+
+  /* Block access to the bus */
+  spi_acquire_bus(spi_num);
+
+  /* enable clock gate */
+  spi_start(spi_num);
+
+  /* Clear MDIS to enable the module. */
+  BITBAND_REG(SPI[spi_num]->MCR, SPI_MCR_MDIS_SHIFT) = 0;
+
+  /* Enable master mode, select chip select signal polarity */
+  /* XXX: Hard-coded chip select active low */
+  /* Disable FIFOs, this can be improved in the future */
+  SPI[spi_num]->MCR = SPI_MCR_MSTR_MASK | SPI_MCR_PCSIS(0x1F) | SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK;
+
+  /* Enable interrupts for TCF flag */
+  BITBAND_REG(SPI[spi_num]->RSER, SPI_RSER_TCF_RE_SHIFT) = 1;
+  NVIC_EnableIRQ(SPI0_IRQn);
+
+  /* disable clock gate */
+  spi_stop(spi_num);
+
+  /* Allow access to the bus */
+  spi_release_bus(spi_num);
+}
+
+void spi_set_params(const spi_bus_t spi_num, const uint8_t ctas, const spi_config_t* config) {
+  uint32_t ctar = 0;
+
+  /* All of the SPI modules run on the Bus clock */
+  find_closest_scalers(SystemBusClock, config->sck_freq, &ctar);
+
+  /* FMSZ equals the frame size + 1 */
+  ctar |= SPI_CTAR_FMSZ(config->frame_size - 1);
+
+  if (config->cpol != 0) {
+    ctar |= SPI_CTAR_CPOL_MASK;
+  }
+  if (config->cpha != 0) {
+    ctar |= SPI_CTAR_CPHA_MASK;
+  }
+
+  SPI[spi_num]->CTAR[ctas] = ctar;
+  spi_conf[spi_num][ctas] = config;
+}
+
+void spi_refresh_params(void) {
+  int spi_num;
+  int ctas;
+
+  for (spi_num = 0; spi_num < NUM_SPI; ++spi_num) {
+    for (ctas = 0; ctas < NUM_CTAR; ++ctas) {
+      if (spi_conf[spi_num][ctas] != NULL) {
+        spi_set_params(spi_num, ctas, spi_conf[spi_num][ctas]);
+      }
+    }
+  }
+}
+
+int spi_transfer_blocking(const spi_bus_t spi_num, const uint8_t ctas, const uint32_t cs,
+             const spi_transfer_flag_t cont, const uint8_t *data_out,
+             uint8_t *data_in, size_t count_out, size_t count_in)
+{
+  SPI_Type *spi_dev = SPI[spi_num];
+  /* Frame size in bits */
+  unsigned short frame_size = ((SPI[spi_num]->CTAR[ctas] & SPI_CTAR_FMSZ_MASK) >> SPI_CTAR_FMSZ_SHIFT) + 1;
+
+  /* Array stride in bytes */
+  /* unsigned int stride = (frame_size / 8) + 1; */
+
+  uint32_t common_flags = SPI_PUSHR_CTAS(ctas) | SPI_PUSHR_PCS(cs);
+
+  uint32_t spi_pushr;
+
+  /* this may yield unaligned memory accesses because of uint8_t* casted to
+   * uint16_t*. Using the DMA module will avoid this. */
+  if (frame_size > 8) {
+    /* Error! not implemented yet */
+    DEBUGGER_BREAK(BREAK_INVALID_PARAM);
+    while(1);
+  }
+
+  while (count_out > 0) {
+    spi_pushr = common_flags;
+    spi_pushr |= SPI_PUSHR_TXDATA(*data_out);
+    ++data_out; /* or += stride */
+    --count_out;
+
+    /* See if we are at the end yet */
+    if((count_out > 0) || (count_in > 0) || (cont == SPI_TRANSFER_CONT)) {
+      spi_pushr |= SPI_PUSHR_CONT_MASK;
+    }
+
+    /* Clear transfer complete flag */
+    spi_dev->SR |= SPI_SR_TCF_MASK;
+
+    /* Set waiting flag */
+    spi_waiting_flag[spi_num] = 1;
+
+    /* Shift a frame out/in */
+    spi_dev->PUSHR = spi_pushr;
+
+    /* Wait for transfer complete */
+    COND_WAIT(spi_waiting_flag[spi_num] != 0);
+
+    /* Do a dummy read in order to allow for the next byte to be read */
+    uint8_t tmp = spi_dev->POPR;
+    (void)tmp; /* Suppress warning about unused value. */
+
+  }
+
+  /* Prepare read */
+  spi_pushr = common_flags;
+  spi_pushr |= SPI_PUSHR_TXDATA(SPI_IDLE_DATA);
+  spi_pushr |= SPI_PUSHR_CONT_MASK;
+
+  /* Do a number of reads */
+  while (count_in > 0) {
+    --count_in;
+    /* See if we are at the end yet */
+    if((count_in < 1) && (cont != SPI_TRANSFER_CONT)) {
+      /* Disable CS line after the next transfer */
+      spi_pushr &= ~(SPI_PUSHR_CONT_MASK);
+    }
+
+    /* Clear transfer complete flag */
+    spi_dev->SR |= SPI_SR_TCF_MASK;
+
+    /* Set waiting flag */
+    spi_waiting_flag[spi_num] = 1;
+
+    /* Shift a frame out/in */
+    spi_dev->PUSHR = spi_pushr;
+
+    /* Wait for transfer complete */
+    COND_WAIT(spi_waiting_flag[spi_num] != 0);
+
+    (*data_in) = spi_dev->POPR;
+    ++data_in; /* or += stride */
+  }
+
+  return 0;
+}
+
+void spi_start(const spi_bus_t spi_num)
+{
+  /* Enable clock gate for the correct SPI hardware module */
+  switch(spi_num) {
+    case 0:
+      BITBAND_REG(SIM->SCGC6, SIM_SCGC6_SPI0_SHIFT) = 1;
+      break;
+    case 1:
+      BITBAND_REG(SIM->SCGC6, SIM_SCGC6_SPI1_SHIFT) = 1;
+      break;
+    case 2:
+      BITBAND_REG(SIM->SCGC3, SIM_SCGC3_SPI2_SHIFT) = 1;
+      break;
+  }
+}
+
+void spi_stop(const spi_bus_t spi_num)
+{
+  /* Enable clock gate for the correct SPI hardware module */
+  switch(spi_num) {
+    case 0:
+      BITBAND_REG(SIM->SCGC6, SIM_SCGC6_SPI0_SHIFT) = 0;
+      break;
+    case 1:
+      BITBAND_REG(SIM->SCGC6, SIM_SCGC6_SPI1_SHIFT) = 0;
+      break;
+    case 2:
+      BITBAND_REG(SIM->SCGC3, SIM_SCGC3_SPI2_SHIFT) = 0;
+      break;
+  }
+}
+
+/** \todo SPI: Handle all flags properly in ISR, remove assumption on TCF. */
+
+/**
+ * ISR for handling bus transfer complete interrupts.
+ */
+void _isr_spi0(void) {
+  /* Clear status flag by writing a 1 to it */
+  BITBAND_REG(SPI0->SR, SPI_SR_TCF_SHIFT) = 1;
+  spi_waiting_flag[0] = 0;
+}
+
+void _isr_spi1(void) {
+  /* Clear status flag by writing a 1 to it */
+  BITBAND_REG(SPI1->SR, SPI_SR_TCF_SHIFT) = 1;
+  spi_waiting_flag[1] = 0;
+}

--- a/cpu/arm/k60/include/system_MK60D10.h
+++ b/cpu/arm/k60/include/system_MK60D10.h
@@ -86,6 +86,10 @@ extern uint32_t SystemFlexBusClock;
  */
 extern uint32_t SystemFlashClock;
 
+/**
+ * \brief PIT module clock_delay_usec scale factor
+ */
+extern uint32_t PIT_ticks_per_usec;
 
 /**
  * \brief Setup the microcontroller system.

--- a/cpu/arm/k60/system_MK60D10.c
+++ b/cpu/arm/k60/system_MK60D10.c
@@ -50,6 +50,7 @@ uint32_t SystemSysClock = DEFAULT_SYSTEM_CLOCK; /* Current system clock frequenc
 uint32_t SystemBusClock = DEFAULT_SYSTEM_CLOCK; /* Current bus clock frequency */
 uint32_t SystemFlexBusClock = DEFAULT_SYSTEM_CLOCK; /* Current FlexBus clock frequency */
 uint32_t SystemFlashClock = DEFAULT_SYSTEM_CLOCK; /* Current flash clock frequency */
+uint32_t PIT_ticks_per_usec = DEFAULT_SYSTEM_CLOCK / 1000000;
 
 /* Initialize RTC oscillator as early as possible since we are using it as a
  * base clock for the FLL.
@@ -279,4 +280,13 @@ void SystemCoreClockUpdate(void) {
   SystemBusClock = (MCGOUTClock / (1u + ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV2_MASK) >> SIM_CLKDIV1_OUTDIV2_SHIFT)));
   SystemFlexBusClock = (MCGOUTClock / (1u + ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV3_MASK) >> SIM_CLKDIV1_OUTDIV3_SHIFT)));
   SystemFlashClock = (MCGOUTClock / (1u + ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV4_MASK) >> SIM_CLKDIV1_OUTDIV4_SHIFT)));
+
+  /* Module helper variables */
+  if (SystemBusClock >= 1000000) {
+    /* PIT module clock_delay_usec scale factor */
+    PIT_ticks_per_usec = (SystemBusClock + 500000) / 1000000; /* Rounded to nearest integer */
+  } else {
+    /* less than 1 MHz clock frequency on the PIT module, round up. */
+    PIT_ticks_per_usec = 1;
+  }
 }

--- a/platform/mulle/Makefile.mulle
+++ b/platform/mulle/Makefile.mulle
@@ -21,6 +21,7 @@ CONTIKI_TARGET_MAIN = ${CONTIKI_CORE}.o
 CONTIKI_TARGET_SOURCEFILES += contiki-main.c \
   devicemap.c \
   udelay.c \
+  spi-config.c \
   init-net.c \
   watchdog.c \
   slip_arch_uart.c \

--- a/platform/mulle/config-board.h
+++ b/platform/mulle/config-board.h
@@ -156,6 +156,25 @@ extern "C" {
 /* enable 12pF load capacitance, might need adjusting.. */
 #define BOARD_RTC_LOAD_CAP_BITS (RTC_CR_SC8P_MASK | RTC_CR_SC4P_MASK)
 
+/**
+ * PIT channel to use for clock_delay_usec and clock_delay_msec.
+ *
+ * Note: Make sure this channel is not used elsewhere (asynchronously).
+ */
+#define BOARD_DELAY_PIT_CHANNEL 0
+
+#define PIT_ISR_GLUE2(CHANNEL) (_isr_pit ## CHANNEL)
+#define PIT_ISR_GLUE(CHANNEL) PIT_ISR_GLUE2(CHANNEL)
+/**
+ * PIT channel interrupt used by clock_delay_usec and clock_delay_msec.
+ */
+#define BOARD_DELAY_PIT_ISR PIT_ISR_GLUE(BOARD_DELAY_PIT_CHANNEL)
+
+#define PIT_IRQn_GLUE2(CHANNEL) (PIT ## CHANNEL ## _IRQn)
+#define PIT_IRQn_GLUE(CHANNEL) PIT_IRQn_GLUE2(CHANNEL)
+
+#define BOARD_DELAY_PIT_IRQn PIT_IRQn_GLUE(BOARD_DELAY_PIT_CHANNEL)
+
 
 /*
  * 1-wire bus configuration.

--- a/platform/mulle/config-board.h
+++ b/platform/mulle/config-board.h
@@ -138,6 +138,12 @@ extern "C" {
 #define NUM_UARTS 5
 
 /**
+ * Number of SPI modules in CPU.
+ */
+#define NUM_SPI 3
+
+
+/**
  * UART module used for SLIP communications.
  *
  * This string is passed to open() during slip_init_arch().
@@ -175,6 +181,49 @@ extern "C" {
 
 #define BOARD_DELAY_PIT_IRQn PIT_IRQn_GLUE(BOARD_DELAY_PIT_CHANNEL)
 
+/*
+ * The onboard LIS3DH is connected to SPI0.
+ * SPI0_PCS0 is the active low CS signal.
+ */
+#define LIS3DH_SPI_NUM 0
+#define LIS3DH_CHIP_SELECT_PIN 0
+/*
+ * See spi-config.c for the CTAR configuration
+ */
+#define LIS3DH_CTAS 1
+
+/*
+ * The onboard AT86RF212/AT86RF230 is connected to SPI0.
+ * SPI0_PCS1 is the active low CS signal.
+ */
+#define AT86RF212_SPI_NUM 0
+#define AT86RF212_CHIP_SELECT_PIN 1
+/*
+ * See spi-config.c for the CTAR configuration
+ */
+#define AT86RF212_CTAS 0
+
+/*
+ * The onboard M25P16 flash memory is connected to SPI0.
+ * SPI0_PCS2 is the active low CS signal.
+ */
+#define FLASH_SPI_NUM 0
+#define FLASH_CHIP_SELECT_PIN 2
+/*
+ * See spi-config.c for the CTAR configuration
+ */
+#define FLASH_CTAS 1
+
+/*
+ * The onboard FM25L04 FRAM memory is connected to SPI0.
+ * SPI0_PCS2 is the active low CS signal.
+ */
+#define FRAM_SPI_NUM 0
+#define FRAM_CHIP_SELECT_PIN 3
+/*
+ * See spi-config.c for the CTAR configuration
+ */
+#define FRAM_CTAS 1
 
 /*
  * 1-wire bus configuration.

--- a/platform/mulle/contiki-main.c
+++ b/platform/mulle/contiki-main.c
@@ -13,6 +13,7 @@
 #include "core-clocks.h"
 #include "uart.h"
 #include "udelay.h"
+#include "clock.h"
 #include "llwu.h"
 #include "init-net.h"
 #include "power-control.h"
@@ -22,6 +23,8 @@
 #include "devicemap.h"
 #include "random.h"
 #include "rtc.h"
+#include "spi-config.h"
+#include "spi-k60.h"
 
 #define DEBUG 1
 #if DEBUG
@@ -98,9 +101,12 @@ main(void)
   power_control_vperiph_set(1);
 
   udelay_init();
-  udelay(0xFFFF);
-  udelay(0xFFFF);
-  random_init((unsigned short)SIM->UIDL);
+
+  /* Initialize SPI bus driver */
+  board_spi_init();
+  /** \todo make SPI0 on-demand clocked. */
+  spi_start(0);
+
 #ifndef WITH_SLIP
   PRINTF("Booted\n");
   PRINTF("CPUID: %08x\n", (unsigned int)SCB->CPUID);
@@ -111,14 +117,15 @@ main(void)
   /*
    * Initialize Contiki and our processes.
    */
+  random_init((unsigned short)SIM->UIDL);
   rtimer_init();
+  clock_init();
 
   process_init();
   process_start(&etimer_process, NULL);
 
   ctimer_init();
 
-  clock_init();
   init_cfs();
   init_net();
   voltage_init();

--- a/platform/mulle/dev/lis3dh-arch.c
+++ b/platform/mulle/dev/lis3dh-arch.c
@@ -37,54 +37,19 @@
  *         Joakim Gebart <joakim.gebart@eistec.se>
  */
 
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 #include "lis3dh.h"
 #include "K60.h"
+#include "config-board.h"
 #include "interrupt.h"
 #include "power-control.h"
-#include <stdint.h>
-#include <stdbool.h>
+#include "spi-k60.h"
 
-#define LIS3DH_CHIP_SELECT_PIN 0
-#define LIS3DH_CTAS 1
+/* Convenience macro */
+#define LIS3DH_CHIP_SELECT_PIN_MASK (1 << LIS3DH_CHIP_SELECT_PIN)
 
-/**
- * Perform a one byte transfer over SPI.
- *
- * \param data The data to write to the slave.
- * \param cont If set, keep asserting the chip select pin after the current byte transfer ends.
- * \param blocking If set, wait until all bits have been transferred before returning.
- * \return The byte received from the slave during the same transfer.
- *
- * \note There is no need for separate read and write functions, since SPI transfers work like a shift register (one bit out, one bit in.)
- *
- * \todo Make SPI abstraction standalone.
- */
-static uint8_t
-spi_transfer(const uint8_t data, const bool cont, const bool blocking)
-{
-  uint32_t spi_pushr;
-
-  spi_pushr = SPI_PUSHR_TXDATA(data);
-  spi_pushr |= SPI_PUSHR_CTAS(LIS3DH_CTAS);
-  spi_pushr |= SPI_PUSHR_PCS((1 << LIS3DH_CHIP_SELECT_PIN));
-  if(cont) {
-    spi_pushr |= SPI_PUSHR_CONT_MASK;
-  }
-
-  /* Clear transfer complete flag */
-  SPI0->SR |= SPI_SR_TCF_MASK;
-
-  /* Shift a frame out/in */
-  SPI0->PUSHR = spi_pushr;
-
-  if(blocking) {
-    /* Wait for transfer complete */
-    while(!(SPI0->SR & SPI_SR_TCF_MASK)) ;
-  }
-
-  /* Pop the buffer */
-  return 0xFF & SPI0->POPR;
-}
 /**
  * Write a single byte to the LIS3DH.
  *
@@ -94,10 +59,20 @@ spi_transfer(const uint8_t data, const bool cont, const bool blocking)
 void
 lis3dh_write_byte(const lis3dh_reg_addr_t addr, const uint8_t value)
 {
-  MK60_ENTER_CRITICAL_REGION();
-  spi_transfer((addr & LIS3DH_SPI_ADDRESS_MASK) | LIS3DH_SPI_WRITE_MASK | LIS3DH_SPI_SINGLE_MASK, true, true);  /* Write address */
-  spi_transfer(value, false, true);     /* Write data */
-  MK60_LEAVE_CRITICAL_REGION();
+  uint8_t data_out[2];
+
+  /* Address field */
+  data_out[0] = (addr & LIS3DH_SPI_ADDRESS_MASK) | LIS3DH_SPI_WRITE_MASK | LIS3DH_SPI_SINGLE_MASK;
+  /* value field */
+  data_out[1] = value;
+
+  /* Acquire exclusive access to the bus. */
+  spi_acquire_bus(LIS3DH_SPI_NUM);
+  /* Perform the transaction */
+  spi_transfer_blocking(LIS3DH_SPI_NUM, LIS3DH_CTAS, LIS3DH_CHIP_SELECT_PIN_MASK,
+    SPI_TRANSFER_DONE, &data_out[0], NULL, sizeof(data_out)/sizeof(data_out[0]), 0);
+  /* Release the bus for other threads. */
+  spi_release_bus(LIS3DH_SPI_NUM);
 }
 /**
  * Read a single byte from the LIS3DH.
@@ -108,14 +83,20 @@ lis3dh_write_byte(const lis3dh_reg_addr_t addr, const uint8_t value)
 uint8_t
 lis3dh_read_byte(const lis3dh_reg_addr_t addr)
 {
-  uint8_t data;
+  uint8_t data_out = (addr & LIS3DH_SPI_ADDRESS_MASK) | LIS3DH_SPI_READ_MASK | LIS3DH_SPI_SINGLE_MASK;
+  uint8_t data_in;
 
-  MK60_ENTER_CRITICAL_REGION();
-  spi_transfer((addr & LIS3DH_SPI_ADDRESS_MASK) | LIS3DH_SPI_READ_MASK | LIS3DH_SPI_SINGLE_MASK, true, true);   /* Write address */
-  data = spi_transfer(0, false, true);  /* Dummy write to get data */
-  MK60_LEAVE_CRITICAL_REGION();
-  return data;
+  /* Acquire exclusive access to the bus. */
+  spi_acquire_bus(LIS3DH_SPI_NUM);
+  /* Perform the transaction */
+  spi_transfer_blocking(LIS3DH_SPI_NUM, LIS3DH_CTAS, LIS3DH_CHIP_SELECT_PIN_MASK,
+    SPI_TRANSFER_DONE, &data_out, &data_in, 1, 1);
+  /* Release the bus for other threads. */
+  spi_release_bus(LIS3DH_SPI_NUM);
+
+  return data_in;
 }
+
 /**
  * Read a 16-bit integer from the LIS3DH.
  *
@@ -126,65 +107,51 @@ lis3dh_read_byte(const lis3dh_reg_addr_t addr)
 int16_t
 lis3dh_read_int16(const lis3dh_reg_addr_t lsb_addr)
 {
-  int16_t data;
+  /* Address field */
+  uint8_t data_out = (lsb_addr & LIS3DH_SPI_ADDRESS_MASK) | LIS3DH_SPI_READ_MASK | LIS3DH_SPI_MULTI_MASK;
+  /* value field */
+  uint8_t data_in[2];
 
-  MK60_ENTER_CRITICAL_REGION();
+  int16_t ret;
 
   /*
    * We will do a multi byte read from the LIS3DH.
    * After the first read the address will be automatically increased by one.
    */
-  /* Write address */
-  spi_transfer((lsb_addr & LIS3DH_SPI_ADDRESS_MASK) |
-               LIS3DH_SPI_READ_MASK | LIS3DH_SPI_MULTI_MASK, true, true);
 
-  /*
-   * Do not modify the following two statements into a single statement, the
-   * spi_transfer calls must be made in the right order.
-   * Google "sequence points".
-   */
-  data = spi_transfer(0xFF, true, true);        /* Read LSB, keep holding chip select active. */
-  data |= (spi_transfer(0xFF, false, true) << 8);       /* Read MSB, release chip select. */
+  /* Acquire exclusive access to the bus. */
+  spi_acquire_bus(LIS3DH_SPI_NUM);
+  /* Perform the transaction */
+  spi_transfer_blocking(LIS3DH_SPI_NUM, LIS3DH_CTAS, LIS3DH_CHIP_SELECT_PIN_MASK,
+    SPI_TRANSFER_DONE, &data_out, &data_in[0], 1, 2);
+  /* Release the bus for other threads. */
+  spi_release_bus(LIS3DH_SPI_NUM);
 
-  MK60_LEAVE_CRITICAL_REGION();
-  return (int16_t)data;
+  ret = (int16_t)((data_in[1] << 8) | data_in[0]);
+
+  return ret;
 }
 /**
  * Read multiple bytes from the LIS3DH.
  *
  * \param start_address The lower address of the source registers.
  * \param buffer A buffer to write the read values into.
- * \param count Number of bytes to read.
+ * \param count Number of bytes to read, must not be greater than 31.
  */
 void
 lis3dh_memcpy_from_device(const lis3dh_reg_addr_t start_address,
                           uint8_t *buffer, uint8_t count)
 {
-  /*
-   * This function must not be interrupted by anything using the SPI bus or
-   * it will mess up the transfer.
-   */
-  MK60_ENTER_CRITICAL_REGION();
+  /* Address field */
+  uint8_t data_out = (start_address & LIS3DH_SPI_ADDRESS_MASK) | LIS3DH_SPI_READ_MASK | LIS3DH_SPI_MULTI_MASK;
 
-  /*
-   * We will do a multi byte read from the LIS3DH.
-   * After the first read the address will be automatically increased by one
-   * for each subsequent transfer.
-   */
-  /* Write address */
-  spi_transfer((start_address & LIS3DH_SPI_ADDRESS_MASK) |
-               LIS3DH_SPI_READ_MASK | LIS3DH_SPI_MULTI_MASK, true, true);
-
-  while(count > 1) {
-    /* Read byte, keep holding chip select active. */
-    *buffer = spi_transfer(0xFF, true, true);
-    ++buffer;
-    --count;
-  }
-  /* Read last byte, release chip select. */
-  *buffer = spi_transfer(0xFF, false, true);
-
-  MK60_LEAVE_CRITICAL_REGION();
+  /* Acquire exclusive access to the bus. */
+  spi_acquire_bus(LIS3DH_SPI_NUM);
+  /* Perform the transaction */
+  spi_transfer_blocking(LIS3DH_SPI_NUM, LIS3DH_CTAS, LIS3DH_CHIP_SELECT_PIN_MASK,
+    SPI_TRANSFER_DONE, &data_out, buffer, 1, count);
+  /* Release the bus for other threads. */
+  spi_release_bus(LIS3DH_SPI_NUM);
 }
 /**
  * Write multiple bytes to the LIS3DH.
@@ -197,64 +164,17 @@ void
 lis3dh_memcpy_to_device(const lis3dh_reg_addr_t start_address,
                         const uint8_t *buffer, uint8_t count)
 {
-  /*
-   * This function must not be interrupted by anything using the SPI bus or
-   * it will mess up the transfer.
-   */
-  MK60_ENTER_CRITICAL_REGION();
+  /* Address field */
+  uint8_t data_out = (start_address & LIS3DH_SPI_ADDRESS_MASK) | LIS3DH_SPI_WRITE_MASK | LIS3DH_SPI_MULTI_MASK;
 
-  /*
-   * We will do a multi byte write to the LIS3DH.
-   * After the first write the address will be automatically increased by one
-   * for each subsequent transfer.
-   */
-  /* Write address */
-  spi_transfer((start_address & LIS3DH_SPI_ADDRESS_MASK) |
-               LIS3DH_SPI_WRITE_MASK | LIS3DH_SPI_MULTI_MASK, true, true);
-
-  while(count > 1) {
-    /* Write byte, keep holding chip select active. */
-    spi_transfer(*buffer, true, true);
-    ++buffer;
-    --count;
-  }
-  /* Write last byte, release chip select. */
-  spi_transfer(*buffer, false, true);
-
-  MK60_LEAVE_CRITICAL_REGION();
-}
-/**
- * Perform the platform specific part of the initialization process of the LIS3DH.
- * This function is expected to set up the SPI module for the LIS3DH.
- */
-void
-lis3dh_arch_init()
-{
-  /* Enable clock gate on PTD (for SPI0) */
-  SIM->SCGC5 |= SIM_SCGC5_PORTD_MASK;
-  /* Note: Interrupts will need to enable clock gate on PTC as well */
-
-  /* Enable clock gate for SPI0 module */
-  SIM->SCGC6 |= SIM_SCGC6_SPI0_MASK;
-
-  /* Configure SPI0 */
-  /* Master mode */
-  /* all peripheral chip select signals are active low */
-  /* Disable TX,RX FIFO */
-  SPI0->MCR = SPI_MCR_MSTR_MASK | SPI_MCR_PCSIS(0x1F) | SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK;     /* 0x803F3000; */
-
-  /* 8 bit frame size */
-  /* Set up different delays and clock scalers */
-  /* TODO: These need tuning */
-  /* FIXME: Coordinate SPI0 parameters between different peripheral drivers */
-  /* IMPORTANT: Clock polarity is active low! */
-  SPI0->CTAR[LIS3DH_CTAS] = SPI_CTAR_FMSZ(7) | SPI_CTAR_CSSCK(2) | SPI_CTAR_ASC(2) | SPI_CTAR_DT(2) | SPI_CTAR_BR(4) | SPI_CTAR_CPOL_MASK | SPI_CTAR_CPHA_MASK; /*0x38002224; *//* TODO: Should be able to speed up */
-
-  /* Mux SPI0 on port D */
-  PORTD->PCR[0] = PORT_PCR_MUX(2); /* SPI0_PCS0 */
-  PORTD->PCR[1] = PORT_PCR_MUX(2); /* SPI0_SCK */
-  PORTD->PCR[2] = PORT_PCR_MUX(2); /* SPI0_SOUT */
-  PORTD->PCR[3] = PORT_PCR_MUX(2); /* SPI0_SIN */
-
-  return;
+  /* Acquire exclusive access to the bus. */
+  spi_acquire_bus(LIS3DH_SPI_NUM);
+  /* Send the address */
+  spi_transfer_blocking(LIS3DH_SPI_NUM, LIS3DH_CTAS, LIS3DH_CHIP_SELECT_PIN_MASK,
+    SPI_TRANSFER_CONT, &data_out, NULL, 1, 0);
+  /* Send the data */
+  spi_transfer_blocking(LIS3DH_SPI_NUM, LIS3DH_CTAS, LIS3DH_CHIP_SELECT_PIN_MASK,
+    SPI_TRANSFER_DONE, buffer, NULL, count, 0);
+  /* Release the bus for other threads. */
+  spi_release_bus(LIS3DH_SPI_NUM);
 }

--- a/platform/mulle/dev/lis3dh.c
+++ b/platform/mulle/dev/lis3dh.c
@@ -255,14 +255,14 @@ lis3dh_set_scale(const lis3dh_scale_t scale)
 /**
  * Initialize a LIS3DH accelerometer.
  *
+ * SPI is assumed to be initialized beforehand.
+ *
  * \todo Signal errors when initializing the LIS3DH hardware.
  */
 void
 lis3dh_init()
 {
   uint8_t databyte;
-
-  lis3dh_arch_init();
 
   databyte = lis3dh_read_byte(WHO_AM_I);
   if(databyte != LIS3DH_WHO_AM_I_RESPONSE) {

--- a/platform/mulle/dev/xmem.c
+++ b/platform/mulle/dev/xmem.c
@@ -13,17 +13,13 @@
 void
 xmem_init(void)
 {
-  MK60_ENTER_CRITICAL_REGION();
   flash_init();
-  MK60_LEAVE_CRITICAL_REGION();
 }
 int
 xmem_pread(void *buf, int nbytes, unsigned long offset)
 {
   flash_error_t r;
-  MK60_ENTER_CRITICAL_REGION();
   r = flash_readi(FLASH_ID0, offset, buf, nbytes, FLASH_WAIT);
-  MK60_LEAVE_CRITICAL_REGION();
   if(r == E_FLASH_OK) {
     return nbytes;
   }
@@ -33,9 +29,7 @@ int
 xmem_pwrite(const void *buf, int nbytes, unsigned long offset)
 {
   flash_error_t r;
-  MK60_ENTER_CRITICAL_REGION();
   r = flash_writei(FLASH_ID0, offset, (uint8_t *)buf, nbytes, FLASH_WAIT | FLASH_FINISH);
-  MK60_LEAVE_CRITICAL_REGION();
   if(r == E_FLASH_OK) {
     return nbytes;
   }
@@ -58,9 +52,7 @@ xmem_erase(long nbytes, unsigned long offset)
   first = offset / FLASH_SECTOR_SIZE;
   for(i = first; i < (first + nbytes / FLASH_SECTOR_SIZE); ++i) {
     flash_error_t r;
-    MK60_ENTER_CRITICAL_REGION();
     r = flash_erase_sector(FLASH_ID0, i, FLASH_WAIT | FLASH_FINISH);
-    MK60_LEAVE_CRITICAL_REGION();
     if(r != E_FLASH_OK) {
       /* TODO(henrik) fix return code so that number of erased bytes is returned. */
       return 0;

--- a/platform/mulle/spi-config.c
+++ b/platform/mulle/spi-config.c
@@ -1,0 +1,60 @@
+/*
+ * Configuration for SPI0 bus.
+ */
+
+/*
+ * Onboard devices connected:
+ *  AT86RF212: max sck frequency 7.5 MHz (async) 8000000 (sync), CPOL = 0, CPHA = 0, but seems to work with CPOL=1, CPHA=1 as well.
+ *  LIS3DH: max sck frequency 10 MHz, CPOL = 1, CPHA = 1
+ *  M25P16: max sck frequency 25 MHz, (CPOL=0, CPHA=0) or (CPOL=1, CPHA=1)
+ *  FM25L04B: max sck frequency 20 MHz, (CPOL=0, CPHA=0) or (CPOL=1, CPHA=1)
+ *
+ * The AT86RF212 is allocated to CTAR0, the rest at CTAR1.
+ * FIXME: The memories could be driven faster.
+ */
+
+#include "spi-k60.h"
+
+static const spi_config_t spi0_conf[NUM_CTAR] = {
+  { .sck_freq = 7500000, .frame_size = 8, .cpol = 0, .cpha = 0},
+  { .sck_freq = 10000000, .frame_size = 8, .cpol = 1, .cpha = 1}
+  };
+
+/* SPI1 is only used by expansion boards. */
+/*
+static const spi_config_t spi1_conf[NUM_CTAR] = {
+  { .sck_freq = 1000000, .frame_size = 8, .cpol = 0, .cpha = 0},
+  { .sck_freq = 10000000, .frame_size = 8, .cpol = 1, .cpha = 1}
+  };
+*/
+
+/* Set port mux for SPI0 bus */
+static void port_init_spi0(void) {
+  /* Turn on port */
+  BITBAND_REG(SIM->SCGC5, SIM_SCGC5_PORTD_SHIFT) = 1;
+  /* Set up mux */
+  /** \todo Update SPI pin mapping to more dynamic format. (remove magic numbers) */
+  PORTD->PCR[0] = PORT_PCR_MUX(2); /* SPI0_PCS0 */
+  PORTD->PCR[1] = PORT_PCR_MUX(2); /* SPI0_SCLK */
+  PORTD->PCR[2] = PORT_PCR_MUX(2); /* SPI0_MOSI */
+  PORTD->PCR[3] = PORT_PCR_MUX(2); /* SPI0_MISO */
+  PORTD->PCR[4] = PORT_PCR_MUX(2); /* SPI0_PCS1 */
+  PORTD->PCR[5] = PORT_PCR_MUX(2); /* SPI0_PCS2 */
+  PORTD->PCR[6] = PORT_PCR_MUX(2); /* SPI0_PCS3 */
+}
+
+/* Board or project specific SPI initialization procedure. */
+void
+board_spi_init(void)
+{
+  int i;
+  port_init_spi0();
+  /* SPI0 is used for onboard peripherals */
+  spi_hw_init_master(0);
+  spi_start(0);
+  for (i = 0; i < NUM_CTAR; ++i) {
+    spi_set_params(0, i, &spi0_conf[i]);
+  }
+  spi_stop(0);
+}
+

--- a/platform/mulle/spi-config.h
+++ b/platform/mulle/spi-config.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014, Eistec AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Mulle platform port of the Contiki operating system.
+ *
+ */
+
+#ifndef SPI_CONFIG_H_
+#define SPI_CONFIG_H_
+
+/**
+ * Initialize the on board SPI bus with configuration settings from spi-config.c.
+ */
+void board_spi_init(void);
+
+#endif /* SPI_CONFIG_H_ */


### PR DESCRIPTION
This PR implements a common SPI bus master driver for the K60.
All Mulle SPI device drivers are converted to the common API, except the radio, which will be added in another PR.