### PR TITLE
cpu/arm/k60: Add missing PIT_ticks_per_usec

### DIFF
--- a/cpu/arm/k60/include/system_MK60DZ10.h
+++ b/cpu/arm/k60/include/system_MK60DZ10.h
@@ -86,6 +86,10 @@ extern uint32_t SystemFlexBusClock;
  */
 extern uint32_t SystemFlashClock;
 
+/**
+ * \brief PIT module clock_delay_usec scale factor
+ */
+extern uint32_t PIT_ticks_per_usec;
 
 /**
  * \brief Setup the microcontroller system.


### PR DESCRIPTION
Added missing declaration of PIT_ticks_per_usec to rev 1.x header files.

Signed-off-by: Joakim Gebart joakim.gebart@eistec.se

Fixes build error on prototype Mulles with K60 rev 1.4
