### PR TITLE
Add listing and search tools for FTDI devices

### DIFF
--- a/cpu/arm/k60/Makefile.k60
+++ b/cpu/arm/k60/Makefile.k60
@@ -156,10 +156,6 @@ CPU_STARTOBJ=${addprefix $(OBJECTDIR)/,$(CPU_STARTC:.c=.o)}
 
 PROJECT_OBJECTFILES += ${addprefix $(OBJECTDIR)/,$(CONTIKI_TARGET_MAIN:.c=.o)}
 
-ifeq ($(PORT),)
-  PORT=/dev/ttyUSB0
-endif
-
 ### Compilation rules
 all:
 

--- a/platform/mulle/Makefile.mulle
+++ b/platform/mulle/Makefile.mulle
@@ -105,7 +105,19 @@ OOCD_BOARD_FLAGS ?= -f '$(PLATFORM_DIR)/tools/openocd/mulle-programmer-$(PROGRAM
 # Add serial matching command
 ifneq ($(PROGRAMMER_SERIAL),)
   OOCD_BOARD_FLAGS += -c 'ftdi_serial $(PROGRAMMER_SERIAL)'
+
+  ifeq ($(PORT),)
+    # try to find tty name by serial number, only works on Linux currently.
+    ifeq ($(HOST_OS),Linux)
+      PORT :=$(shell $(PLATFORM_DIR)/tools/find-tty.sh $(PROGRAMMER_SERIAL))
+    endif
+  endif
 endif
+
+ifeq ($(PORT),)
+  PORT=/dev/ttyUSB0
+endif
+
 
 ifeq ($(FILENAME),)
 FILENAME = $(CONTIKI_PROJECT).$(TARGET)

--- a/platform/mulle/tools/find-tty.sh
+++ b/platform/mulle/tools/find-tty.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Usage:
+# find-tty.sh [serial] - gives first tty assigned to the given serial number.
+
+# Find all FT2232H devices
+for dev in /sys/bus/usb/devices/*; do
+    if [ ! -f "${dev}/idVendor" ]; then
+        # not a main device
+        continue
+    fi
+    # filter out any devices not identified as 0403:6010
+    if grep -v '0403' "${dev}/idVendor" -q; then
+        continue
+    fi
+    if grep -v '6010' "${dev}/idProduct" -q; then
+        continue
+    fi
+    serial=$(cat "${dev}/serial")
+    # Look if any subdevices have a tty directory, this means that it is assigned a port.
+    unset ttys
+    ttys=$(ls "${dev}:"*/tty* -d -1 | xargs -n 1 basename)
+    if [ -z "${ttys}" ]; then
+        continue
+    fi
+    # split results into array
+    read -r -a ttys <<< ${ttys}
+    for s in "${@}"; do
+        if [ "${serial}" == "${s}" ]; then
+            # return first tty
+            echo "/dev/${ttys[0]}"
+            exit 0;
+        fi
+    done
+done
+# not found
+exit 1;

--- a/platform/mulle/tools/list-programmers.sh
+++ b/platform/mulle/tools/list-programmers.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "These are the currently connected FTDI devices:"
+
+# Find all FT2232H devices
+for dev in /sys/bus/usb/devices/*; do
+    if [ ! -f "${dev}/idVendor" ]; then
+        # not a main device
+        continue
+    fi
+    # filter out any devices not identified as 0403:6010
+    if grep -v '0403' "${dev}/idVendor" -q; then
+        continue
+    fi
+    if grep -v '6010' "${dev}/idProduct" -q; then
+        continue
+    fi
+    manuf=$(cat "${dev}/manufacturer")
+    product=$(cat "${dev}/product")
+    serial=$(cat "${dev}/serial")
+    # Look if any subdevices have a tty directory, this means that it is assigned a port.
+    ttys=$(ls "${dev}:"*/tty* -d -1 | xargs -n 1 basename)
+    echo "${dev}: ${manuf} ${product} serial: '${serial}', tty(s): $(for t in ${ttys}; do echo -n "${t}, "; done)"
+done


### PR DESCRIPTION
These scripts can be used to find the ttyUSB* device of an attached programmer based on serial number instead of guessing depending on the chronological order the physical devices were connected.

I have updated Makefile.mulle to attempt to search for the tty if `PROGRAMMER_SERIAL` is set but `PORT` is not set.