### PR TITLE
platform/mulle: Rename MULLE_BOARD_SERIAL_NUMBER -> MULLE_SERIAL

### DIFF
--- a/platform/mulle/Makefile.mulle
+++ b/platform/mulle/Makefile.mulle
@@ -54,8 +54,19 @@ ifdef UIP_CONF_IPV6
 CFLAGS += -DWITH_UIP6=1
 endif
 
+# Backwards compatibility with older environment settings (.profile, .bashrc etc.)
+# MULLE_SERIAL was called MULLE_BOARD_SERIAL_NUMBER previously.
 ifdef MULLE_BOARD_SERIAL_NUMBER
-CFLAGS += -DMULLE_BOARD_SERIAL_NUMBER=$(MULLE_BOARD_SERIAL_NUMBER)
+  ifeq ($(MULLE_SERIAL),)
+    MULLE_SERIAL=$(MULLE_BOARD_SERIAL_NUMBER)
+  endif
+endif
+
+# MULLE_SERIAL is used to select which specific Mulle board we are compiling for.
+# This was called MULLE_BOARD_SERIAL_NUMBER previously, renamed because
+# MULLE_BOARD_SERIAL_NUMBER is too long to type.
+ifdef MULLE_SERIAL
+  CFLAGS += -DMULLE_SERIAL=$(MULLE_SERIAL)
 endif
 
 include $(PLATFORM_DIR)/radio/rf230bb/Makefile.rf230bb

--- a/platform/mulle/config-board.h
+++ b/platform/mulle/config-board.h
@@ -52,12 +52,12 @@ extern "C" {
 /**
  * CPU silicon revision (some registers are moved or added between revisions 1 and 2)
  */
-#if !defined(MULLE_BOARD_SERIAL_NUMBER)
+#if !defined(MULLE_SERIAL)
 /* Default to revision 2 unless the serial number is specified in the build. */
 #define K60_CPU_REV 2
-#elif defined(MULLE_BOARD_SERIAL_NUMBER) && \
-  (MULLE_BOARD_SERIAL_NUMBER >= 200) && \
-  (MULLE_BOARD_SERIAL_NUMBER <= 219)
+#elif defined(MULLE_SERIAL) && \
+  (MULLE_SERIAL >= 200) && \
+  (MULLE_SERIAL <= 219)
 /* Only Mulles with serial numbers 200 through 219 have revision 1.x silicon
  * (revision 1.4, 4N30D mask set), see the sticker on the CPU top on the Mulle */
 #define K60_CPU_REV 1


### PR DESCRIPTION
`MULLE_BOARD_SERIAL_NUMBER` was getting tedious to type on the command line when moving between different boards frequently.
Also `MULLE_SERIAL` is better wrt to consistency with `PROGRAMMER_SERIAL`.

Added a backwards compatibility clause in `Makefile.mulle` to cope with older environment settings still left in users' `.bashrc` files.