### PR TITLE
ds18b20: Add support for DS1820 and DS18S20 sensors

### DIFF
--- a/cpu/arm/k60/drivers/ds18b20.c
+++ b/cpu/arm/k60/drivers/ds18b20.c
@@ -82,23 +82,82 @@ ds18b20_convert_temperature(const ow_rom_code_t id)
  * \return 0 if the CRC is correct, non-zero otherwise.
  */
 uint8_t
-ds18b20_read_scratchpad(const ow_rom_code_t id, uint8_t *dest)
+ds18b20_read_scratchpad(const ow_rom_code_t id, ds18b20_scratchpad_t *dest)
 {
   static const ds18b20_cmd_t cmd = DS18B20_READ_SCRATCHPAD;
-  uint16_t buf;
+  int16_t buf;
   int i;
 
   ow_skip_or_match_rom(id);
   ow_write_bytes((const uint8_t *)&cmd, 1);
-  ow_read_bytes(&dest[0], DS18B20_SCRATCHPAD_SIZE);
+  ow_read_bytes((uint8_t *)dest, DS18B20_SCRATCHPAD_SIZE);
   printf("Scratchpad: ");
-  for(i = 0; i < DS18B20_SCRATCHPAD_SIZE / 2; ++i) {
-    buf = (dest[2 * i] << 8) | (dest[2 * i + 1]);
-    printf("%x", buf);
+  for(i = 0; i < DS18B20_SCRATCHPAD_SIZE; ++i) {
+    printf("%02x", ((uint8_t *)dest)[i]);
   }
   printf("\n");
-  printf("CRC: %x (should be %x)\n", dest[8], ow_compute_crc(dest, 8));
-  buf = (dest[1] << 8) | dest[0];
-  printf("Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f) * 625);
-  return ow_compute_crc(dest, DS18B20_SCRATCHPAD_SIZE);
+  printf("CRC: %x (should be %x)\n", dest->crc, ow_compute_crc((uint8_t *)dest, DS18B20_SCRATCHPAD_SIZE - 1));
+  buf = (dest->temp_msb << 8) | dest->temp_lsb;
+  /* ds18b20: */
+  //~ printf("Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f) * 625);
+  /* ds1820, ds18s20: */
+  printf("Temp (celsius): %d.%d\n", (buf >> 1), (buf & 0x01) * 5);
+  return ow_compute_crc((uint8_t *)dest, DS18B20_SCRATCHPAD_SIZE);
+}
+
+/**
+ * Parse the scratchpad contents of a DS18B20 sensor and return the degrees as float.
+ *
+ * \param scratch Scratchpad contents, use ds18b20_read_scratchpad() to fill.
+ *
+ * \note Check the return value of ds18b20_read_scratchpad for error handling,
+ *       this function only does some simple arithmetic on the given values.
+ *
+ * \return a float temperature in celsius.
+ */
+float ds18b20_parse_scratchpad_float(const ds18b20_scratchpad_t *scratch)
+{
+  int16_t buf;
+  float ret = 0.0;
+  buf = (scratch->temp_msb << 8) | scratch->temp_lsb;
+  printf("Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f)*625);
+
+  /* float transformation */
+  ret = buf / 16.0f;
+
+  return ret;
+}
+
+/**
+ * Parse the scratchpad of a DS18S20 or DS1820 sensor and return the degrees as float.
+ *
+ * \param scratch Scratchpad contents, use ds18b20_read_scratchpad() to fill.
+ *
+ * \note Check the return value of ds18b20_read_scratchpad for error handling,
+ *       this function only does some simple arithmetic on the given values.
+ *
+ * \return a float temperature in celsius.
+ */
+float ds18s20_parse_scratchpad_float(const ds18b20_scratchpad_t *scratch)
+{
+  /* Increase resolution by using extra information, as per DS1820 data sheet. */
+  int16_t buf;
+  float ret = 0.0;
+  buf = (scratch->temp_msb << 8) | scratch->temp_lsb;
+
+  /* Truncate lsbit */
+  buf &= ~(0x01);
+  buf <<= 3;
+  /* Now at same scale as ds18b20 (but not same accuracy!) */
+  /* Increase accuracy by the method described in the data sheet. */
+  ret = (16 * (int16_t)(scratch->count_per_c - scratch->count_remain));
+  ret /= scratch->count_per_c;
+  ret += buf / 4;
+
+  printf("DS1820 Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f) * 625);
+
+  /* float transformation */
+  ret = buf / 16.0f;
+
+  return ret;
 }

--- a/cpu/arm/k60/drivers/ds18b20.c
+++ b/cpu/arm/k60/drivers/ds18b20.c
@@ -41,8 +41,15 @@
 
 #include "onewire.h"
 #include "ds18b20.h"
-#include "stdio.h"
 #include "stdbool.h"
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) PRINTF(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
 
 /**
  * Initialize the DS18B20 driver.
@@ -67,11 +74,6 @@ ds18b20_convert_temperature(const ow_rom_code_t id)
 
   ow_skip_or_match_rom(id);
   ow_write_bytes((const uint8_t *)&cmd, 1);
-  /* Keep reading to see status of the conversion, the response will be 1 for as
-   * long as the conversion is in progress, then change to 0. */
-  /*uint8_t status = 0;*/
-  /*ow_read_bytes(&status, 1);*/
-  /*printf("status: %x\n");*/
 }
 /**
  * Read the scratchpad of a DS18B20 sensor.
@@ -91,17 +93,17 @@ ds18b20_read_scratchpad(const ow_rom_code_t id, ds18b20_scratchpad_t *dest)
   ow_skip_or_match_rom(id);
   ow_write_bytes((const uint8_t *)&cmd, 1);
   ow_read_bytes((uint8_t *)dest, DS18B20_SCRATCHPAD_SIZE);
-  printf("Scratchpad: ");
+  PRINTF("Scratchpad: ");
   for(i = 0; i < DS18B20_SCRATCHPAD_SIZE; ++i) {
-    printf("%02x", ((uint8_t *)dest)[i]);
+    PRINTF("%02x", ((uint8_t *)dest)[i]);
   }
-  printf("\n");
-  printf("CRC: %x (should be %x)\n", dest->crc, ow_compute_crc((uint8_t *)dest, DS18B20_SCRATCHPAD_SIZE - 1));
+  PRINTF("\n");
+  PRINTF("CRC: %x (should be %x)\n", dest->crc, ow_compute_crc((uint8_t *)dest, DS18B20_SCRATCHPAD_SIZE - 1));
   buf = (dest->temp_msb << 8) | dest->temp_lsb;
   /* ds18b20: */
-  //~ printf("Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f) * 625);
+  //~ PRINTF("Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f) * 625);
   /* ds1820, ds18s20: */
-  printf("Temp (celsius): %d.%d\n", (buf >> 1), (buf & 0x01) * 5);
+  PRINTF("Temp (celsius): %d.%d\n", (buf >> 1), (buf & 0x01) * 5);
   return ow_compute_crc((uint8_t *)dest, DS18B20_SCRATCHPAD_SIZE);
 }
 
@@ -120,7 +122,7 @@ float ds18b20_parse_scratchpad_float(const ds18b20_scratchpad_t *scratch)
   int16_t buf;
   float ret = 0.0;
   buf = (scratch->temp_msb << 8) | scratch->temp_lsb;
-  printf("Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f)*625);
+  PRINTF("Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f)*625);
 
   /* float transformation */
   ret = buf / 16.0f;
@@ -154,7 +156,7 @@ float ds18s20_parse_scratchpad_float(const ds18b20_scratchpad_t *scratch)
   ret /= scratch->count_per_c;
   ret += buf / 4;
 
-  printf("DS1820 Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f) * 625);
+  PRINTF("DS1820 Temp (celsius): %d.%d\n", (buf >> 4), (buf & 0x0f) * 625);
 
   /* float transformation */
   ret = buf / 16.0f;

--- a/cpu/arm/k60/drivers/ds18b20.h
+++ b/cpu/arm/k60/drivers/ds18b20.h
@@ -59,9 +59,23 @@ typedef enum {
   DS18B20_READ_SCRATCHPAD = 0xBE
 } ds18b20_cmd_t;
 
+typedef struct __attribute__((__packed__)) ds18b20_scratchpad {
+  uint8_t temp_lsb;
+  uint8_t temp_msb;
+  uint8_t user1;
+  uint8_t user2;
+  uint8_t configuration;
+  uint8_t reserved_ff;
+  uint8_t count_remain;
+  uint8_t count_per_c;
+  uint8_t crc;
+} ds18b20_scratchpad_t;
+
 void ds18b20_init(void);
 void ds18b20_convert_temperature(const ow_rom_code_t id);
-uint8_t ds18b20_read_scratchpad(const ow_rom_code_t id, uint8_t *dest);
+uint8_t ds18b20_read_scratchpad(const ow_rom_code_t id, ds18b20_scratchpad_t *dest);
+float ds18b20_parse_scratchpad_float(const ds18b20_scratchpad_t *scratch);
+float ds18s20_parse_scratchpad_float(const ds18b20_scratchpad_t *scratch);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/cpu/arm/k60/drivers/onewire.c
+++ b/cpu/arm/k60/drivers/onewire.c
@@ -56,8 +56,17 @@
 #include "uart.h"
 #include "port.h"
 #include "config-clocks.h"
-#include <stdio.h>
 #include <stdint.h>
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) PRINTF(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+
 
 /* Convenience macro, ONEWIRE_UART_NUM is defined by the platform. */
 #define ONEWIRE_UART UART[ONEWIRE_UART_NUM]
@@ -426,7 +435,7 @@ ow_read_rom(void)
   uint8_t i;
   ow_rom_code_t rom_code;
   static const ow_rom_cmd_t cmd = ONEWIRE_CMD_READ_ROM;
-  printf("READ ROM: ");
+  PRINTF("READ ROM: ");
   ow_reset();
   ow_write_bytes((const uint8_t *)(&cmd), 1);
   ow_read_bytes(rom, ONEWIRE_ROM_CODE_LENGTH);
@@ -445,10 +454,10 @@ ow_read_rom(void)
 
   for(i = 0; i < sizeof(rom) / 2; ++i) {
     buf = (rom[2 * i] << 8) | (rom[2 * i + 1]);
-    printf("%x", buf);
+    PRINTF("%x", buf);
   }
-  printf("\n");
-  printf("CRC: 0x%x\n", ow_compute_crc(rom, ONEWIRE_ROM_CODE_LENGTH));
+  PRINTF("\n");
+  PRINTF("CRC: 0x%x\n", ow_compute_crc(rom, ONEWIRE_ROM_CODE_LENGTH));
   return rom_code;
 }
 /**
@@ -460,7 +469,7 @@ void
 ow_skip_rom(void)
 {
   static const ow_rom_cmd_t cmd = ONEWIRE_CMD_SKIP_ROM;
-  printf("SKIP ROM\n");
+  PRINTF("SKIP ROM\n");
   ow_reset();
   ow_write_bytes((const uint8_t *)(&cmd), 1);
 }
@@ -477,7 +486,7 @@ ow_match_rom(const ow_rom_code_t id)
 {
   static ow_rom_code_t rom_code;
   static const ow_rom_cmd_t cmd = ONEWIRE_CMD_MATCH_ROM;
-  printf("MATCH ROM\n");
+  PRINTF("MATCH ROM\n");
   ow_reset();
   ow_write_bytes((const uint8_t *)(&cmd), 1);
   /* Copy from stack to a static variable to avoid messing up the buffer when


### PR DESCRIPTION
Added support for older DS1820 sensor and its drop-in replacement DS18S20.
Based on #41 