### PR TITLE
cpu/arm/k60: add -fsigned-char to CFLAGS

### DIFF
--- a/cpu/arm/k60/Makefile.k60
+++ b/cpu/arm/k60/Makefile.k60
@@ -125,7 +125,7 @@ endif
 LINKERSCRIPTPATH = $(CONTIKI_CPU)/ldscripts
 LINKERSCRIPT = $(CPU_PART).ld
 #AROPTS   = rv
-CFLAGS   += $(CFLAGSNO)  $(DEBUG) -O$(OPTI) $(OPTFLAGS) -Wall -Werror=implicit-function-declaration -fno-common -fno-strict-aliasing -mcpu=cortex-m4 -mthumb -ffunction-sections -fdata-sections -fshort-enums $(NEWLIB_INCLUDES)
+CFLAGS   += $(CFLAGSNO)  $(DEBUG) -O$(OPTI) $(OPTFLAGS) -Wall -Werror=implicit-function-declaration -fno-common -fno-strict-aliasing -mcpu=cortex-m4 -mthumb -ffunction-sections -fdata-sections -fshort-enums -fsigned-char $(NEWLIB_INCLUDES)
 LDFLAGS  += $(CFLAGS) -nostartfiles -Wl,-L$(LINKERSCRIPTPATH) -T $(LINKERSCRIPT) -Wl,-Map=$@.map -Wl,--gc-sections
 
 LD_START_GROUP ?= -Wl,--start-group


### PR DESCRIPTION
Compiling with Clang yielded warnings (on some systems) because char being
unsigned by default on ARM:

      CC        ../../../core/net/ipv6/uip-ds6.c
    ../../../core/net/ipv6/uip-ds6.c:392:34: warning: comparison of
          constant -1 with expression of type 'int8_t' (aka 'char') is
          always false [-Wtautological-constant-out-of-range-compare]
        if(locaddr->isused && (state == -1 || locaddr->state == state)
                               ~~~~~ ^  ~~
    ../../../core/net/ipv6/uip-ds6.c:411:34: warning: comparison of
          constant -1 with expression of type 'int8_t' (aka 'char') is
          always false [-Wtautological-constant-out-of-range-compare]
        if(locaddr->isused && (state == -1 || locaddr->state == state)
                               ~~~~~ ^  ~~
    2 warnings generated.

with -fsigned-char int8_t is signed, as is expected by Contiki.

Signed-off-by: Joakim Gebart <joakim.gebart@eistec.se>