### PR TITLE
slip-radio: add support for Mulle

### DIFF
--- a/examples/ipv6/slip-radio/Makefile
+++ b/examples/ipv6/slip-radio/Makefile
@@ -22,6 +22,9 @@ endif
 ifeq ($(TARGET),econotag)
   PROJECT_SOURCEFILES += slip-radio-mc1322x.c
 endif
+ifeq ($(TARGET),mulle)
+  PROJECT_SOURCEFILES += slip-radio-rf230.c
+endif
 
 CONTIKI_WITH_RPL = 0
 CONTIKI_WITH_IPV6 = 1

--- a/examples/ipv6/slip-radio/project-conf.h
+++ b/examples/ipv6/slip-radio/project-conf.h
@@ -34,7 +34,7 @@
 #define QUEUEBUF_CONF_NUM          4
 
 #undef UIP_CONF_BUFFER_SIZE
-#define UIP_CONF_BUFFER_SIZE    140
+#define UIP_CONF_BUFFER_SIZE    2048
 
 #undef UIP_CONF_ROUTER
 #define UIP_CONF_ROUTER                 0
@@ -50,6 +50,8 @@
 #define CMD_CONF_HANDLERS slip_radio_cmd_handler,cmd_handler_rf230
 #elif CONTIKI_TARGET_ECONOTAG
 #define CMD_CONF_HANDLERS slip_radio_cmd_handler,cmd_handler_mc1322x
+#elif CONTIKI_TARGET_MULLE
+#define CMD_CONF_HANDLERS slip_radio_cmd_handler,cmd_handler_rf230
 #else
 #define CMD_CONF_HANDLERS slip_radio_cmd_handler
 #endif
@@ -60,8 +62,8 @@
 #define NETSTACK_CONF_MAC     nullmac_driver
 
 #undef NETSTACK_CONF_RDC
-/* #define NETSTACK_CONF_RDC     nullrdc_noframer_driver */
-#define NETSTACK_CONF_RDC     contikimac_driver
+#define NETSTACK_CONF_RDC     nullrdc_noframer_driver
+//#define NETSTACK_CONF_RDC     contikimac_driver
 
 #undef NETSTACK_CONF_NETWORK
 #define NETSTACK_CONF_NETWORK slipnet_driver

--- a/examples/ipv6/slip-radio/slip-radio-rf230.c
+++ b/examples/ipv6/slip-radio/slip-radio-rf230.c
@@ -34,7 +34,6 @@
 #include "contiki.h"
 #include "cmd.h"
 
-#include "radio/rf230/radio.h"
 #include "radio/rf230bb/rf230bb.h"
 
 

--- a/examples/ipv6/slip-radio/slip-radio.c
+++ b/examples/ipv6/slip-radio/slip-radio.c
@@ -62,6 +62,8 @@ static int slip_radio_cmd_handler(const uint8_t *data, int len);
 
 #if CONTIKI_TARGET_NOOLIBERRY
 int cmd_handler_rf230(const uint8_t *data, int len);
+#elif CONTIKI_TARGET_MULLE
+int cmd_handler_rf230(const uint8_t *data, int len);
 #elif CONTIKI_TARGET_ECONOTAG
 int cmd_handler_mc1322x(const uint8_t *data, int len);
 #else /* Leave CC2420 as default */


### PR DESCRIPTION
Useful for reading raw 802.15.4 frames.

Increases buffer size in slip-radio as well.