### PR TITLE
UART cleanup and use hardware FIFO

### DIFF
--- a/platform/mulle/dev/slip_arch_uart.c
+++ b/platform/mulle/dev/slip_arch_uart.c
@@ -16,7 +16,8 @@ slip_arch_init(unsigned long ubr)
 {
   /* ubr is the desired baud rate, but the name comes from the msp430 platform
    * where baud is converted to some platform specific "UBR" parameter. */
-  /** \todo (MULLE) Handle baud rate requests in slip_arch_init */
+  /* (re-)initialize the UART module */
+  uart_init(BOARD_SLIP_UART_NUM, 0, ubr);
 
   int fd;
   struct stat st;


### PR DESCRIPTION
This PR fixes some errors in the UART driver and adds support for the hardware FIFOs present in the K60. Using FIFO mode for RX I can use 921600 baud for the SLIP link without any dropped bytes.