### PR TITLE
k60: clock: Disable interrupts after servicing the delay interrupt.

### DIFF
--- a/cpu/arm/k60/clock.c
+++ b/cpu/arm/k60/clock.c
@@ -186,4 +186,7 @@ void BOARD_DELAY_PIT_ISR(void) {
 
   /* Clear flag set by clock_delay_usec() */
   waiting_flag = 0;
+
+  /* Disable interrupts */
+  BITBAND_REG(PIT->CHANNEL[BOARD_DELAY_PIT_CHANNEL].TCTRL, PIT_TCTRL_TIE_SHIFT) = 0;
 }


### PR DESCRIPTION
Could cause endless ISR loops otherwise.