### PR TITLE
mulle: Reduce baud rate to 115200 again

### DIFF
--- a/examples/ipv6/rpl-border-router/slip-bridge.c
+++ b/examples/ipv6/rpl-border-router/slip-bridge.c
@@ -50,7 +50,7 @@
 #include "net/ip/uip-debug.h"
 
 #ifndef SLIP_BRIDGE_BAUD
-#define SLIP_BRIDGE_BAUD 921600
+#define SLIP_BRIDGE_BAUD 115200
 #endif
 
 void set_prefix_64(uip_ipaddr_t *);

--- a/examples/ipv6/slip-radio/slip-radio.c
+++ b/examples/ipv6/slip-radio/slip-radio.c
@@ -173,7 +173,7 @@ init(void)
 #ifndef BAUD2UBR
 #define BAUD2UBR(baud) baud
 #endif
-  slip_arch_init(BAUD2UBR(921600));
+  slip_arch_init(BAUD2UBR(115200));
   process_start(&slip_process, NULL);
   slip_set_input_callback(slip_input_callback);
   packet_pos = 0;

--- a/platform/mulle/config-board.h
+++ b/platform/mulle/config-board.h
@@ -100,7 +100,7 @@ extern "C" {
 /**
  * Baud rate of debug UART.
  */
-#define BOARD_DEBUG_UART_BAUD 921600
+#define BOARD_DEBUG_UART_BAUD 115200
 
 /**
  * PORT module containing the TX pin of the debug UART.


### PR DESCRIPTION
921600 caused communication issues for the rpl-border-router under
certain conditions.