### PR TITLE
k60: Update GPIO driver to latest RIOT version

### DIFF
--- a/cpu/arm/k60/include/RIOT/periph/gpio.h
+++ b/cpu/arm/k60/include/RIOT/periph/gpio.h
@@ -64,46 +64,47 @@
 extern "C" {
 #endif
 
-/**
- * @brief   Default GPIO macro maps port-pin tuples to the pin value
- */
-#ifndef GPIO_PIN
-#define GPIO_PIN(x,y)       ((x & 0) | y)
-#endif
-
-/**
- * @brief   Define global value for GPIO not defined
- */
-#ifndef GPIO_UNDEF
-#define GPIO_UNDEF          (UINT_MAX)
-#endif
-
-/**
- * @brief   Define the default GPIO type identifier
- */
 #ifndef HAVE_GPIO_T
+/**
+ * @brief   GPIO type identifier
+ */
 typedef unsigned int gpio_t;
 #endif
 
+#ifndef GPIO_PIN
 /**
- * @brief   Definition of available pin directions
+ * @brief   Convert (port, pin) tuple to @c gpio_t value
  */
-#ifndef HAVE_GPIO_DIR_T
-typedef enum {
-    GPIO_DIR_IN = 0,        /**< configure pin as input */
-    GPIO_DIR_OUT = 1        /**< configure pin as output */
-} gpio_dir_t;
+/* Default GPIO macro maps port-pin tuples to the pin value */
+#define GPIO_PIN(x,y)       ((gpio_t)((x & 0) | y))
+#endif
+
+#ifndef GPIO_UNDEF
+/**
+ * @brief   GPIO pin not defined
+ */
+#define GPIO_UNDEF          ((gpio_t)(UINT_MAX))
 #endif
 
 /**
- * @brief   Definition of pull-up/pull-down modes
+ * @brief   Available pin modes
+ *
+ * Generally, a pin can be configured to be input or output. In output mode, a
+ * pin can further be put into push-pull or open drain configuration. Though
+ * this is supported by most platforms, this is not always the case, so driver
+ * implementations may return an error code if a mode is not supported.
  */
-#ifndef HAVE_GPIO_PP_T
+#ifndef HAVE_GPIO_MODE_T
 typedef enum {
-    GPIO_NOPULL = 0,        /**< do not use internal pull resistors */
-    GPIO_PULLUP = 1,        /**< enable internal pull-up resistor */
-    GPIO_PULLDOWN = 2       /**< enable internal pull-down resistor */
-} gpio_pp_t;
+    GPIO_IN ,               /**< configure as input without pull resistor */
+    GPIO_IN_PD,             /**< configure as input with pull-down resistor */
+    GPIO_IN_PU,             /**< configure as input with pull-up resistor */
+    GPIO_OUT,               /**< configure as output in push-pull mode */
+    GPIO_OD,                /**< configure as output in open-drain mode without
+                             *   pull resistor */
+    GPIO_OD_PU              /**< configure as output in open-drain mode with
+                             *   pull resistor enabled */
+} gpio_mode_t;
 #endif
 
 /**
@@ -140,13 +141,12 @@ typedef struct {
  * @brief   Initialize the given pin as general purpose input or output
  *
  * @param[in] pin       pin to initialize
- * @param[in] dir       direction for the pin, input or output
- * @param[in] pullup    define what pull resistors should be used
+ * @param[in] mode      mode of the pin, see @c gpio_mode_t
  *
  * @return              0 on success
  * @return              -1 on error
  */
-int gpio_init(gpio_t pin, gpio_dir_t dir, gpio_pp_t pullup);
+int gpio_init(gpio_t pin, gpio_mode_t mode);
 
 /**
  * @brief   Initialize a GPIO pin for external interrupt usage
@@ -157,7 +157,7 @@ int gpio_init(gpio_t pin, gpio_dir_t dir, gpio_pp_t pullup);
  * The interrupt is activated automatically after the initialization.
  *
  * @param[in] pin       pin to initialize
- * @param[in] pullup    define what pull resistors should be enabled
+ * @param[in] mode      mode of the pin, see @c gpio_mode_t
  * @param[in] flank     define the active flank(s)
  * @param[in] cb        callback that is called from interrupt context
  * @param[in] arg       optional argument passed to the callback
@@ -165,18 +165,18 @@ int gpio_init(gpio_t pin, gpio_dir_t dir, gpio_pp_t pullup);
  * @return              0 on success
  * @return              -1 on error
  */
-int gpio_init_int(gpio_t pin, gpio_pp_t pullup, gpio_flank_t flank,
-                    gpio_cb_t cb, void *arg);
+int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                  gpio_cb_t cb, void *arg);
 
 /**
- * @brief   Enable pin's interrupt if configured as interrupt source
+ * @brief   Enable pin interrupt if configured as interrupt source
  *
  * @param[in] pin       the pin to enable the interrupt for
  */
 void gpio_irq_enable(gpio_t pin);
 
 /**
- * @brief   Disable the pin's interrupt if configured as interrupt source
+ * @brief   Disable the pin interrupt if configured as interrupt source
  *
  * @param[in] pin       the pin to disable the interrupt for
  */
@@ -186,10 +186,9 @@ void gpio_irq_disable(gpio_t pin);
  * @brief   Get the current value of the given pin
  *
  * @param[in] pin       the pin to read
- * @return              the current value, 0 for LOW, != 0 for HIGH
  *
  * @return              0 when pin is LOW
- * @return              greater 0 for HIGH
+ * @return              >0 for HIGH
  */
 int gpio_read(gpio_t pin);
 

--- a/platform/mulle/dev/leds-arch.c
+++ b/platform/mulle/dev/leds-arch.c
@@ -8,9 +8,9 @@
 void
 leds_arch_init(void)
 {
-  gpio_init(LED_RED_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init(LED_YELLOW_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init(LED_GREEN_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
+  gpio_init(LED_RED_GPIO, GPIO_OUT);
+  gpio_init(LED_YELLOW_GPIO, GPIO_OUT);
+  gpio_init(LED_GREEN_GPIO, GPIO_OUT);
 }
 /*---------------------------------------------------------------------------*/
 unsigned char

--- a/platform/mulle/dev/power-control.c
+++ b/platform/mulle/dev/power-control.c
@@ -46,9 +46,9 @@
 void
 power_control_init(void)
 {
-  gpio_init(MULLE_POWER_VPERIPH, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init(MULLE_POWER_VSEC, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init(MULLE_POWER_AVDD, GPIO_DIR_OUT, GPIO_NOPULL);
+  gpio_init(MULLE_POWER_VPERIPH, GPIO_OUT);
+  gpio_init(MULLE_POWER_VSEC, GPIO_OUT);
+  gpio_init(MULLE_POWER_AVDD, GPIO_OUT);
 }
 
 void

--- a/platform/mulle/radio/rf212/at86rf212_hal.c
+++ b/platform/mulle/radio/rf212/at86rf212_hal.c
@@ -81,10 +81,10 @@ hal_init(void)
 {
   /*** IO Specific Initialization.****/
 
-  gpio_init(SLPTR_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init(RST_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init(PWR_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init_int(IRQ_GPIO, GPIO_NOPULL, GPIO_RISING, hal_isr, NULL);
+  gpio_init(SLPTR_GPIO, GPIO_OUT);
+  gpio_init(RST_GPIO, GPIO_OUT);
+  gpio_init(PWR_GPIO, GPIO_OUT);
+  gpio_init_int(IRQ_GPIO, GPIO_IN, GPIO_RISING, hal_isr, NULL);
 
   /* Enable power switch to radio */
   hal_set_pwr_high();

--- a/platform/mulle/radio/rf230bb/halbb.c
+++ b/platform/mulle/radio/rf230bb/halbb.c
@@ -195,10 +195,10 @@ hal_init(void)
 {
   /*** IO Specific Initialization.****/
 
-  gpio_init(SLPTR_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init(RST_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init(PWR_GPIO, GPIO_DIR_OUT, GPIO_NOPULL);
-  gpio_init_int(IRQ_GPIO, GPIO_NOPULL, GPIO_RISING, hal_rf230_isr, NULL);
+  gpio_init(SLPTR_GPIO, GPIO_OUT);
+  gpio_init(RST_GPIO, GPIO_OUT);
+  gpio_init(PWR_GPIO, GPIO_OUT);
+  gpio_init_int(IRQ_GPIO, GPIO_IN, GPIO_RISING, hal_rf230_isr, NULL);
 
   /* Enable power switch to radio */
   hal_set_pwr_high();


### PR DESCRIPTION
Including API changes from RIOT-OS/RIOT#4862

I have updated the apps in the drone-experiment branch to work with this version of the GPIO API.