### PR TITLE
mulle: fix warning unused static function in init-net

### DIFF
--- a/platform/mulle/init-net.c
+++ b/platform/mulle/init-net.c
@@ -68,6 +68,7 @@ union {
 
 char mulle_eui64_str[sizeof(mulle_eui64) * 2 + 1];
 
+#if !WITH_SLIP
 /** @brief Simple hash function used for generating link-local IPv6 and EUI64
  *         (64 bit) from CPUID (128 bit)
  *
@@ -83,6 +84,7 @@ djb2_hash(const uint8_t *buf, size_t len)
 
     return hash;
 }
+#endif
 
 /*---------------------------------------------------------------------------*/
 static void


### PR DESCRIPTION
fixes

```
../../contiki/platform/mulle/./init-net.c:76:1: warning: 'djb2_hash' defined but not used [-Wunused-function]
 djb2_hash(const uint8_t *buf, size_t len)
 ^
```