### PR TITLE
k60: Update to latest i2c driver

### DIFF
--- a/cpu/arm/k60/include/RIOT/periph/i2c.h
+++ b/cpu/arm/k60/include/RIOT/periph/i2c.h
@@ -55,6 +55,7 @@
 #define I2C_H
 
 #include <stdint.h>
+#include <limits.h>
 
 #include "periph_cpu.h"
 /**
@@ -91,7 +92,7 @@ extern "C" {
  * @{
  */
 #ifndef I2C_UNDEF
-#define I2C_UNDEF           (-1)
+#define I2C_UNDEF           (UINT_MAX)
 #endif
 /** @} */
 
@@ -165,7 +166,7 @@ int i2c_release(i2c_t dev);
  * @return                  -1 on undefined device given
  * @return                  -2 on invalid address
  */
-int i2c_read_byte(i2c_t dev, uint8_t address, char *data);
+int i2c_read_byte(i2c_t dev, uint8_t address, void *data);
 
 /**
  * @brief   Read multiple bytes from an I2C device with the given address
@@ -178,7 +179,7 @@ int i2c_read_byte(i2c_t dev, uint8_t address, char *data);
  * @return                  the number of bytes that were read
  * @return                  -1 on undefined device given
  */
-int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length);
+int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length);
 
 /**
  * @brief   Read one byte from a register at the I2C slave with the given
@@ -192,7 +193,7 @@ int i2c_read_bytes(i2c_t dev, uint8_t address, char *data, int length);
  * @return                  the number of bytes that were read
  * @return                  -1 on undefined device given
  */
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data);
+int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data);
 
 /**
  * @brief   Read multiple bytes from a register at the I2C slave with the given
@@ -208,7 +209,7 @@ int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, char *data);
  * @return                  -1 on undefined device given
  */
 int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg,
-                  char *data, int length);
+                  void *data, int length);
 
 /**
  * @brief   Write one byte to an I2C device with the given address
@@ -220,7 +221,7 @@ int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg,
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_byte(i2c_t dev, uint8_t address, char data);
+int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data);
 
 /**
  * @brief   Write multiple bytes to an I2C device with the given address
@@ -233,7 +234,7 @@ int i2c_write_byte(i2c_t dev, uint8_t address, char data);
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length);
+int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length);
 
 /**
  * @brief   Write one byte to a register at the I2C slave with the given address
@@ -246,7 +247,7 @@ int i2c_write_bytes(i2c_t dev, uint8_t address, char *data, int length);
  * @return                  the number of bytes that were written
  * @return                  -1 on undefined device given
  */
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data);
+int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data);
 
 /**
  * @brief   Write multiple bytes to a register at the I2C slave with the given
@@ -262,7 +263,7 @@ int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, char data);
  * @return                  -1 on undefined device given
  */
 int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg,
-                   char *data, int length);
+                   const void *data, int length);
 
 /**
  * @brief   Power on the given I2C peripheral


### PR DESCRIPTION
Fixes some annoying warnings and unnecessary casts, and fixes an off-by-one error in a specific case of the receive function.