### PR TITLE
k60: Add proper DEBUG macro for ENABLE_DEBUG 1

### DIFF
--- a/cpu/arm/k60/include/debug.h
+++ b/cpu/arm/k60/include/debug.h
@@ -39,8 +39,13 @@
 #ifndef K60_DEBUG_H_
 #define K60_DEBUG_H_
 
+#if ENABLE_DEBUG
+#include <stdio.h>
+#define DEBUG(...) printf(__VA_ARGS__)
+#else
 #ifndef DEBUG
 #define DEBUG(...)
+#endif
 #endif
 
 #endif /* K60_MUTEX_H_ */


### PR DESCRIPTION
Added means of debug output for device drivers etc when reusing code from RIOT.