### PR TITLE
k60: Move udelay to PIT channel 3

### DIFF
--- a/platform/mulle/udelay.c
+++ b/platform/mulle/udelay.c
@@ -29,20 +29,20 @@ udelay(uint16_t us)
   if (us == 0) return;
 
   /* Set up timer */
-  PIT->CHANNEL[0].LDVAL = PIT_LDVAL_TSV((F_BUS / 1000000) * (uint32_t)us);
+  PIT->CHANNEL[3].LDVAL = PIT_LDVAL_TSV((F_BUS / 1000000) * (uint32_t)us);
 
   /* Disable timer to load a new value */
-  BITBAND_REG32(PIT->CHANNEL[0].TCTRL, PIT_TCTRL_TEN_SHIFT) = 0;
+  BITBAND_REG32(PIT->CHANNEL[3].TCTRL, PIT_TCTRL_TEN_SHIFT) = 0;
 
   /* Clear interrupt flag */
-  BITBAND_REG32(PIT->CHANNEL[0].TFLG, PIT_TFLG_TIF_SHIFT) = 1;
+  BITBAND_REG32(PIT->CHANNEL[3].TFLG, PIT_TFLG_TIF_SHIFT) = 1;
 
   /* Enable timer, no interrupt, no chaining */
-  PIT->CHANNEL[0].TCTRL = PIT_TCTRL_TEN_MASK;
+  PIT->CHANNEL[3].TCTRL = PIT_TCTRL_TEN_MASK;
 
   /* Wait for completion */
-  while(!(PIT->CHANNEL[0].TFLG & PIT_TFLG_TIF_MASK));
+  while(!(PIT->CHANNEL[3].TFLG & PIT_TFLG_TIF_MASK));
 
   /* Disable everything */
-  PIT->CHANNEL[0].TCTRL = 0x00;
+  PIT->CHANNEL[3].TCTRL = 0x00;
 }


### PR DESCRIPTION
`clock_delay_usec` and `udelay` were using the same channel, which caused conflicts resulting in a hang in a device driver.