### PR TITLE
k60: llwu: Add ISR callback support for pin interrupts

### DIFF
--- a/cpu/arm/k60/include/llwu.h
+++ b/cpu/arm/k60/include/llwu.h
@@ -101,6 +101,7 @@ typedef enum llwu_wakeup_pin {
   LLWU_WAKEUP_PIN_PTD6 = 15,
   LLWU_WAKEUP_PIN_END
 } llwu_wakeup_pin_t;
+#define LLWU_WAKEUP_PIN_NUMOF 16
 
 typedef enum llwu_wakeup_edge {
   LLWU_WAKEUP_EDGE_DISABLE = 0b00,
@@ -117,6 +118,8 @@ typedef struct llwu_control {
   struct llwu_control *next;
   char allow_llwu;
 } llwu_control_t;
+
+typedef void (*llwu_cb)(void *);
 
 /* Macro to create new llwu control struct for clients. */
 #define LLWU_CONTROL(name) static llwu_control_t name[1] = { { NULL, 1 } } /* default allow deep sleep */
@@ -143,6 +146,7 @@ void llwu_set_allow(llwu_control_t *c, char allow);
 void llwu_enable_wakeup_module(const llwu_wakeup_module_t module);
 void llwu_disable_wakeup_module(const llwu_wakeup_module_t module);
 void llwu_set_wakeup_pin(const llwu_wakeup_pin_t pin, const llwu_wakeup_edge_t edge);
+void llwu_set_wakeup_callback(llwu_wakeup_pin_t pin, llwu_cb cb, void *arg);
 
 /* We can not use a lock variable for the inhibit counters, because that can
  * lead to deadlocks in ISRs, but we can use the exclusive load/store


### PR DESCRIPTION
The interrupt flags in the PORT module are not set when waking from LLS,
we needed another way to trigger pin interrupt handlers when waking.