### PR TITLE
mulle/nvram: return value fix

### DIFF
--- a/platform/mulle/dev/nvram-spi-old.c
+++ b/platform/mulle/dev/nvram-spi-old.c
@@ -132,8 +132,8 @@ static int nvram_spi_write_9bit_addr(const nvram_t *dev, uint8_t *src, uint32_t 
     }
     spi_release_bus(spi_dev->spi);
     K60_LEAVE_CRITICAL_REGION();
-    /* status contains the number of bytes actually written to the SPI bus. */
-    return status;
+    /* status is 0 in Contiki if all went well. */
+    return len;
 }
 
 static int nvram_spi_read_9bit_addr(const nvram_t *dev, uint8_t *dst, uint32_t src, size_t len)
@@ -174,6 +174,6 @@ static int nvram_spi_read_9bit_addr(const nvram_t *dev, uint8_t *dst, uint32_t s
     }
     spi_release_bus(spi_dev->spi);
     K60_LEAVE_CRITICAL_REGION();
-    /* status contains the number of bytes actually read from the SPI bus. */
-    return status;
+    /* status is 0 in Contiki if all went well. */
+    return len;
 }

--- a/platform/mulle/include/mulle-nvram.h
+++ b/platform/mulle/include/mulle-nvram.h
@@ -30,6 +30,12 @@ typedef enum mulle_nvram_address {
     MULLE_NVRAM_MAGIC        = 0x0000,
     /** @brief Reboot counter */
     MULLE_NVRAM_BOOT_COUNT   = 0x0004,
+    /** @brief RTC time backup */
+    MULLE_NVRAM_RTC_BACKUP   = 0x0008,
+    /** @brief Sent packet counter */
+    MULLE_NVRAM_SEND_COUNT   = 0x000C,
+    /** @brief Pulse count */
+    MULLE_NVRAM_PULSE_COUNT  = 0x0014,
 } mulle_nvram_address_t;
 
 #define MULLE_NVRAM_MAGIC_EXPECTED (0x4c4c554dul) /* == "MULL" in ASCII */


### PR DESCRIPTION
This PR corrects the return value of `mulle_nvram->read` and `mulle_nvram->write` to match what the documentation says it should do.

Also added some more NVRAM address constants from the NVRAM document